### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -13,7 +13,7 @@ jobs:
       run: docker build . --file Dockerfile --tag cypher-backend:latest 
      
     - name: Publish to Github Packages Registry
-      uses: elgohr/Publish-Docker-Github-Action@master
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: ${{ secrets.ACTOR }}/cypher-sitejs/cypher-backend
         registry: docker.pkg.github.com


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore